### PR TITLE
fix(outbox): :bug: close *sql.Rows returned by QueryContext with transaction

### DIFF
--- a/pkg/postgres/outbox.go
+++ b/pkg/postgres/outbox.go
@@ -151,10 +151,11 @@ func (p *Postgres) storeOutbox(ctx context.Context, tx *sql.Tx, ob *Outbox) (err
 		return fmt.Errorf("fail to insert to outbox: %w", err)
 	}
 
-	_, err = tx.QueryContext(ctx, "SELECT pg_notify($1, $2)", outboxChannel, ob.CreatedAt.UnixNano())
+	rows, err := tx.QueryContext(ctx, "SELECT pg_notify($1, $2)", outboxChannel, ob.CreatedAt.UnixNano())
 	if err != nil {
 		p.logger.Warn("fail to send notify", log.Error("error", err), log.TraceContext("trace-id", ctx))
 	}
+	defer rows.Close()
 
 	return
 }


### PR DESCRIPTION
Avoid error `pq: unexpected describe rows response: 'D'` when using the tx after storing an outbox, eg :

```go
tx, err := p.BeginTx()

tx.ExecContext(...) // it works

p.storeOutbox(ctx, tx, ob)

tx.ExecContext(...) // error because *sql.Rows inside p.storeOutbox needs to be closed

```

reference :
- https://github.com/lib/pq/issues/142#issuecomment-419101697